### PR TITLE
[pull request]serverchan推送以及action的错误提示

### DIFF
--- a/.github/workflows/sign_in.yml
+++ b/.github/workflows/sign_in.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/.github/workflows/sign_in.yml
+++ b/.github/workflows/sign_in.yml
@@ -29,3 +29,5 @@ jobs:
           PASSWORD: ${{ secrets.PASSWORD }}
           DEBUG: ${{ secrets.DEBUG }}
         run: python main.py
+
+      - uses: gautamkrishnar/keepalive-workflow@v1

--- a/.github/workflows/sign_in.yml
+++ b/.github/workflows/sign_in.yml
@@ -28,6 +28,14 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
           DEBUG: ${{ secrets.DEBUG }}
+          MAIL_ENABLE: ${{ secrets.MAIL_ENABLE }}
+          MAIL_HOST: ${{ secrets.MAIL_HOST }}
+          MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          MAIL_TO: ${{ secrets.MAIL_TO }}
+          SERVERCHAN_ENABLE: ${{ secrets.SERVERCHAN_ENABLE }}
+          SERVERCHAN_KEY: ${{ secrets.SERVERCHAN_KEY }}
         run: python main.py
 
       - uses: gautamkrishnar/keepalive-workflow@v1

--- a/main.py
+++ b/main.py
@@ -23,6 +23,9 @@ mail_username = os.environ.get("MAIL_USERNAME")
 mail_password = os.environ.get("MAIL_PASSWORD")
 mail_to = os.environ.get("MAIL_TO") or []
 
+serverchan_enable = int(os.environ.get("SERVERCHAN_ENABLE") or 0)
+serverchan_key = os.environ.get("SERVERCHAN_KEY")
+
 # 设置日志级别和格式
 if debug == 1:
     logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] [%(asctime)s] %(message)s')
@@ -103,14 +106,17 @@ def is_sign_in():
         if href_value == 'k_misign-sign.html':
             logging.info('已成功签到')
             email_notice('苦力怕论坛自动签到：已成功签到！')
+            serverchan_notice('苦力怕论坛自动签到：已成功签到！')
             exit(0)
         else:
             logging.info('签到失败')
             email_notice('苦力怕论坛自动签到：签到失败')
+            serverchan_notice('苦力怕论坛自动签到：签到失败')
             exit(100)
     else:
         logging.info('签到失败')
         email_notice('苦力怕论坛自动签到：签到失败')
+        serverchan_notice('苦力怕论坛自动签到：签到失败')
         exit(100)
 
 
@@ -134,6 +140,23 @@ def email_notice(msg):
         logging.info('邮件发送失败')
         logging.error(error)
 
+        
+def serverchan_notice(msg):
+    if serverchan_enable == 0:
+        return None
+    url = f"https://sctapi.ftqq.com/{serverchan_key}.send"
+    data = {
+        "title": "苦力怕论坛自动签到",
+        "desp": msg
+    }
+    try:
+        response = requests.post(url, data=data)
+        logging.debug(response.text)
+        logging.info('Server酱消息发送成功')
+    except requests.RequestException as error:
+        logging.info('Server酱消息发送失败')
+        logging.error(error)
+
 
 if __name__ == '__main__':
     logging.debug(f'UserAgent: {userAgent}')
@@ -145,3 +168,4 @@ if __name__ == '__main__':
     sign_in(url)
 
     is_sign_in()
+    


### PR DESCRIPTION
### 增加了serverchan推送
若需启用，需要在secrets中增加两个变量：
1. ```SERVERCHAN_ENABLE```设为```1```（默认```0```）
2. ```SERVERCHAN_KEY```填写server酱的推送key


### 修改了action配置文件
1. 增加了邮件推送部分的环境变量（一定是大佬忘了写
2. 增加了serverchan推送部分的环境变量
3. 修改了一些版本号，主要是因为action黄色感叹号看着碍眼睛
4. 增加了一个步骤，主要是为了防止仓库长时间没有变动，action自动停止
    需要在```Settings```->```Actions```->```General```->```Workflow permissions```，将其设置为```Read repository contents and packages permissions```，也就是可读写，如下图

![1](https://cdn.jsdelivr.net/gh/GrandDuke1106/Imagebed@main/img/2024/01/09/1704784917-%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE%202024-01-09%20152015-250f3c.png)
![2](https://cdn.jsdelivr.net/gh/GrandDuke1106/Imagebed@main/img/2024/01/09/1704784922-%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE%202024-01-09%20152109-15ca61.png)