### PR TITLE
[pull request]支持ntfy推送

### DIFF
--- a/.github/workflows/sign_in.yml
+++ b/.github/workflows/sign_in.yml
@@ -37,6 +37,10 @@ jobs:
           MAIL_TO: ${{ secrets.MAIL_TO }}
           SERVERCHAN_ENABLE: ${{ secrets.SERVERCHAN_ENABLE }}
           SERVERCHAN_KEY: ${{ secrets.SERVERCHAN_KEY }}
+          NTFY_ENABLE: ${{ secrets.NTFY_ENABLE }}
+          NTFY_BASEURL: ${{ secrets.NTFY_BASEURL }}
+          NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
         run: python main.py
 
   keepalive-workflow:

--- a/.github/workflows/sign_in.yml
+++ b/.github/workflows/sign_in.yml
@@ -38,9 +38,11 @@ jobs:
           SERVERCHAN_ENABLE: ${{ secrets.SERVERCHAN_ENABLE }}
           SERVERCHAN_KEY: ${{ secrets.SERVERCHAN_KEY }}
           NTFY_ENABLE: ${{ secrets.NTFY_ENABLE }}
-          NTFY_BASEURL: ${{ secrets.NTFY_BASEURL }}
-          NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+          NTFY_URL: ${{ secrets.NTFY_URL }}
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          NTFY_USERNAME: ${{ secrets.NTFY_USERNAME }}
+          NTFY_PASSWORD: ${{ secrets.NTFY_PASSWORD }}
+          NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
         run: python main.py
 
   keepalive-workflow:

--- a/main.py
+++ b/main.py
@@ -33,8 +33,8 @@ serverchan_key = os.environ.get("SERVERCHAN_KEY")
 
 ntfy_enable = int(os.environ.get("NTFY_ENABLE") or 0)
 ntfy_baseurl = os.environ.get("NTFY_BASEURL") or 'ntfy.sh'
-ntfy_topic = os.environ.get("NTFY_TOPIC")
 ntfy_token = os.environ.get("NTFY_TOKEN")
+ntfy_topic = os.environ.get("NTFY_TOPIC")
 
 # 设置日志级别和格式
 if debug == 1:

--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ def login(username, password):
     # if a_tag is not None:
     #     logging.info('登录成功')
     # else:
-    #     logging.info('登陆失败')
+    #     logging.info('登录失败')
     #     exit(1)
 
 
@@ -91,7 +91,7 @@ def get_url():
         logging.debug(f'签到链接：{sign_in_url}')
 
         if sign_in_url == 'https://klpbbs.com/member.php?mod=logging&action=login':
-            logging.info('签到链接异常（原因：登陆失败）')
+            logging.info('签到链接异常（原因：登录失败）')
             exit(1)
 
         logging.info('已成功获取签到链接')


### PR DESCRIPTION
## 支持ntfy推送
- 增加了四个secrets，当``NTFY_ENABLE``不为0时启用。
    - ntfy有两种验证方式，第一为账号密码，第二为token。``NTFY_ENABLE=1``时，使用账号密码；``NTFY_ENABLE=2``时，使用token。
- 当需要使用账号密码时，将``NTFY_ENABLE``设为``1``，机密``NTFY_TOKEN``设为``账号:密码``（例如：``user:passwd``），使用冒号分隔账号密码；当需要使用token时，将``NTFY_ENABLE``设为``2``，机密``NTFY_TOKEN``设为``:token``（例如：``:tk_wlis9dzu8psln10hwe0qaaaaaaa``），冒号后为token。
- ``NTFY_BASEURL``填入基本域名（默认官网：``ntfy.sh``）；若自建服务端则需要填入你的域名（格式无要求，例如``http://example.com``，``https://example.com``，``https://example.com/``，``example.com``等，若无协议则默认加``https``）
- ``NTFY_TOPIC``填入订阅主题（例如：``klpbbs_auto_sign_in``）


作者看着合并吧，写这个的原因是因为我最近从serverchan推送转移到ntfy推送了（毕竟ntfy可以用fcm做到后台推送）